### PR TITLE
Remove indentation from Makefile.am

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -39,9 +39,9 @@ endif
 if HAVE_INOTIFY
   minidlnad_SOURCES += monitor_inotify.c
 else
-  if HAVE_KQUEUE
-    minidlnad_SOURCES += monitor_kqueue.c
-  endif
+if HAVE_KQUEUE
+  minidlnad_SOURCES += monitor_kqueue.c
+endif
 endif
 
 if HAVE_VORBISFILE

--- a/Makefile.am
+++ b/Makefile.am
@@ -31,13 +31,17 @@ minidlnad_SOURCES = minidlna.c upnphttp.c upnpdescgen.c upnpsoap.c \
 			containers.c avahi.c tagutils/tagutils.c
 
 if HAVE_KQUEUE
-minidlnad_SOURCES += kqueue.c monitor_kqueue.c
+  minidlnad_SOURCES += kqueue.c
 else
-minidlnad_SOURCES += select.c
+  minidlnad_SOURCES += select.c
 endif
 
 if HAVE_INOTIFY
-minidlnad_SOURCES += monitor_inotify.c
+  minidlnad_SOURCES += monitor_inotify.c
+else
+  if HAVE_KQUEUE
+    minidlnad_SOURCES += monitor_kqueue.c
+  endif
 endif
 
 if HAVE_VORBISFILE


### PR DESCRIPTION
On my FreeBSD system, the indentation of the "if HAVE_KQUEUE/endif" block added in commit 1a2dfcc leads to a configure failure of the port at the "depfiles" stage.

This commit removes the indentation, which fixes the problem.

See also https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=288425, which I opened before realizing that the maintainer of this github repo is also the FreeBSD port maintainer.

Closes GH-3